### PR TITLE
Flesh out Fake TrackJS Implementation

### DIFF
--- a/app/initializers/configure-trackjs.js
+++ b/app/initializers/configure-trackjs.js
@@ -1,20 +1,16 @@
 import Ember from 'ember';
 
 export function initialize(container, application) {
+  let trackJs = container.lookup('service:trackjs');
+
   // http://docs.trackjs.com/Examples/Integrating_with_Ember
   Ember.onerror = function (err) {
-    if (window.trackJs) {
-      window.trackJs.track(err);
-    }
-
+    trackJs.track(err);
     Ember.Logger.assert(false, err);
   };
 
   Ember.RSVP.on('error', function (err) {
-    if (window.trackJs) {
-      window.trackJs.track(err);
-    }
-
+    trackJs.track(err);
     Ember.Logger.assert(false, err);
   });
 }

--- a/tests/acceptance/bootstrapping-works-test.js
+++ b/tests/acceptance/bootstrapping-works-test.js
@@ -34,15 +34,13 @@ var dummyConfig = {
 
 module('Acceptance: Bootstrapping Works', {
   beforeEach: function() {
-    window.trackJs = fakeTrackJs;
     application = startApp();
   },
 
   afterEach: function() {
     Ember.run(application, 'destroy');
 
-    fakeTrackJs.reset();
-    window.trackJs = null;
+    window.trackJs._reset();
 
     fakeTrackJsConfig = {};
   }
@@ -82,8 +80,8 @@ test('configuration works', function(assert) {
   visit('/');
 
   andThen(function() {
-    var actualConfiguration = window._trackJs;
-    var expectedConfiguraiton = dummyConfig.trackJs.config;
+    let actualConfiguration = window._trackJs;
+    let expectedConfiguraiton = dummyConfig.trackJs.config;
 
     assert.deepEqual(actualConfiguration, expectedConfiguraiton);
   });
@@ -95,7 +93,7 @@ test('exposes a service on routes', function(assert) {
   visit('/');
 
   andThen(function() {
-    var isErrorFound = fakeTrackJs.errors.contains('route error');
+    let isErrorFound = window.trackJs._errors.contains('route error');
     assert.ok(isErrorFound);
   });
 });
@@ -106,7 +104,7 @@ test('exposes a service on controllers', function(assert) {
   visit('/');
 
   andThen(function() {
-    var isErrorFound = fakeTrackJs.errors.contains('controller error');
+    let isErrorFound = window.trackJs._errors.contains('controller error');
     assert.ok(isErrorFound);
   });
 });

--- a/tests/dummy/public/fake-trackjs.js
+++ b/tests/dummy/public/fake-trackjs.js
@@ -1,3 +1,25 @@
-/**
- * I don't actually want to implement this, it throws off all of the other tests
- */
+window.trackJs = {
+  configure: function(newOpts) {
+    console.log("Configuring");
+
+    var originalOpts = window._trackJs;
+    var modifiedOpts = Ember.merge(originalOpts, newOpts);
+
+    window._trackJs = modifiedOpts;
+  },
+
+  _errors: [],
+
+  track: function(errorOrString) {
+    console.error(errorOrString);
+    this._errors.push(errorOrString);
+  },
+
+  _reset: function() { this.errors = []; },
+
+  attempt: function() { console.log("Attempting"); },
+
+  watch: function() { console.log("Watching"); },
+
+  watchAll: function() { console.log("Watching all"); }
+};


### PR DESCRIPTION
Doing this fixed a lot of weirdo errors I was seeing before. This also
allowed me to use the TrackJS Service directly inside of the
configuration initializer instead of having to reach out to the global.