### PR TITLE
Fix TrackJS Configuration Bug

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -1,0 +1,13 @@
+# Deprecations
+
+## 0.2.0
+
+* Configuration style has changed quite drastically. It turns out that Ember
+  CLI serializes `config/environment.js` into a JSON object. This means
+  certain configuration parameters for TrackJS couldn't be set using this
+  approach (e.g. `onError`). Due to this, an initializer has been introduced.
+  You can generate your own that occurs after 'set-up-trackjs-service', or
+  have one generated for you: `ember generate trackjs-configuration`.
+
+  Two options must unfortunately still be placed in `config/environment.js`:
+  token, and URL. This is due to the way addon loading works.

--- a/app/initializers/bootstrap-trackjs.js
+++ b/app/initializers/bootstrap-trackjs.js
@@ -16,6 +16,6 @@ export function initialize(container, application) {
 }
 
 export default {
-  name: 'configure-trackjs',
+  name: 'bootstrap-trackjs',
   initialize: initialize
 };

--- a/app/initializers/set-up-trackjs-service.js
+++ b/app/initializers/set-up-trackjs-service.js
@@ -4,7 +4,7 @@ export function initialize(container, application) {
 }
 
 export default {
-  name: 'trackjs-service',
+  name: 'set-up-trackjs-service',
   initialize: initialize,
-  after: 'configure-trackjs'
+  after: 'bootstrap-trackjs'
 };

--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/trackjs-configuration/files/app/initializers/configure-trackjs.js
+++ b/blueprints/trackjs-configuration/files/app/initializers/configure-trackjs.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+
+export function initialize(container, application) {
+  let trackJs = container.lookup('service:trackjs');
+
+  // Your TrackJS configuration here!
+  trackJs.configure({
+    enabled: true
+  });
+};
+
+export default {
+  name: 'configure-trackjs',
+  initialize: initialize,
+  after: 'set-up-trackjs-service'
+};

--- a/blueprints/trackjs-configuration/index.js
+++ b/blueprints/trackjs-configuration/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  description: 'Generate an initializer to configure TrackJS',
+
+  // This is to shut Ember CLI up about naming this file
+  normalizeEntityName: function() {}
+};

--- a/index.js
+++ b/index.js
@@ -1,23 +1,20 @@
 /* jshint node: true */
 'use strict';
 
-var defaultAddonConfig = {
-  url: "//d2zah9y47r7bi2.cloudfront.net/releases/current/tracker.js"
-};
-
 module.exports = {
   name: 'ember-cli-trackjs',
 
   contentFor: function (type, config) {
+    var defaultUrl = "//d2zah9y47r7bi2.cloudfront.net/releases/current/tracker.js";
     var trackOpts = config.trackJs || {};
-    var trackConfig = trackOpts.config || {};
-    var addonConfig = trackOpts.addon || defaultAddonConfig;
 
-    var trackConfiguration = '<script type="text/javascript" id="trackjs-configuration">window._trackJs = ' + JSON.stringify(trackConfig) + ';</script>';
-    var trackBoilerPlate = '<script type="text/javascript" id="trackjs-boilerplate" src="' + addonConfig.url + '" crossorigin="anonymous"></script>';
+    var trackToken = trackOpts.token;
+    var trackUrl = trackOpts.url || defaultUrl;
+
+    var trackTag = '<script type="text/javascript" id="trackjs-boilerplate" data-token="' + trackToken + '" src="' + trackUrl + '" crossorigin="anonymous"></script>';
 
     if (type === 'head') {
-      return [trackConfiguration, trackBoilerPlate].join('\n');
+      return trackTag;
     }
   }
 };

--- a/tests/acceptance/bootstrapping-works-test.js
+++ b/tests/acceptance/bootstrapping-works-test.js
@@ -41,16 +41,31 @@ module('Acceptance: Bootstrapping Works', {
   }
 });
 
-test('configuration works', function(assert) {
+test('script tag injection works', function(assert) {
   assert.expect(2);
 
   visit('/');
+
   // womp womp...
   let scriptTag = Ember.$('#trackjs-boilerplate');
 
   andThen(function() {
     assert.equal(scriptTag.data('token'), dummyConfig.trackJs.token);
     assert.equal(scriptTag.attr('src'), dummyConfig.trackJs.url);
+  });
+});
+
+test('configuration works', function(assert) {
+  assert.expect(3);
+
+  visit('/');
+
+  andThen(function() {
+    let actualConfig = window._trackJs;
+
+    assert.equal(typeof actualConfig.onError, 'function');
+    assert.ok(actualConfig.enabled);
+    assert.equal(actualConfig.user, 'timothy');
   });
 });
 

--- a/tests/acceptance/bootstrapping-works-test.js
+++ b/tests/acceptance/bootstrapping-works-test.js
@@ -46,44 +46,16 @@ module('Acceptance: Bootstrapping Works', {
   }
 });
 
-// FIXME Get this to work. It seems like the acceptance tests aren't working correctly
-//
-//test('configuration tag is before library inclusion tag', function(assert) {
-//  assert.expect(1);
-//
-//  visit('/');
-//
-//  andThen(function() {
-//    var scriptTags = find('script');
-//    var isFound = !!find('script#trackjs-configuration + script#trackjs-boilerplate').length;
-//
-//    assert.ok(isFound, 'should be found');
-//  });
-//});
-//
-//test('points to the correct URL', function(assert) {
-//  assert.expect(1);
-//
-//  visit('/');
-//
-//  andThen(function() {
-//    var actualUrl = find('#trackjs-boilerplate').attr('src');
-//    var expectedUrl = dummyConfig.trackJs.addon.url;
-//
-//    assert.equal(actualUrl, expectedUrl);
-//  });
-//});
-
 test('configuration works', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
   visit('/');
+  // womp womp...
+  let scriptTag = Ember.$('#trackjs-boilerplate');
 
   andThen(function() {
-    let actualConfiguration = window._trackJs;
-    let expectedConfiguraiton = dummyConfig.trackJs.config;
-
-    assert.deepEqual(actualConfiguration, expectedConfiguraiton);
+    assert.equal(scriptTag.data('token'), dummyConfig.trackJs.token);
+    assert.equal(scriptTag.attr('src'), dummyConfig.trackJs.url);
   });
 });
 

--- a/tests/acceptance/bootstrapping-works-test.js
+++ b/tests/acceptance/bootstrapping-works-test.js
@@ -22,13 +22,8 @@ var fakeTrackJsConfig = {};
 // You'll have to manually sync this with the config found in the dummy app
 var dummyConfig = {
   trackJs: {
-    addon: {
-      url: '/fake-trackjs.js'
-    },
-
-    config: {
-      token: 'fake-token'
-    }
+    url: '/fake-trackjs.js',
+    token: 'fake-token'
   }
 };
 

--- a/tests/dummy/app/initializers/configure-trackjs.js
+++ b/tests/dummy/app/initializers/configure-trackjs.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+
+export function initialize(container, application) {
+  let trackJs = container.lookup('service:trackjs');
+
+  let options = {
+    enabled: true,
+    user: 'timothy',
+    onError: function() { console.error('Aw, snap!'); }
+  };
+
+  // Your TrackJS configuration here!
+  trackJs.configure(options);
+}
+
+export default {
+  name: 'configure-trackjs',
+  initialize: initialize,
+  after: 'set-up-trackjs-service'
+};

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -19,13 +19,8 @@ module.exports = function(environment) {
     },
 
     trackJs: {
-      addon: {
-        url: '/fake-trackjs.js'
-      },
-
-      config: {
-        token: 'fake-token'
-      }
+      url: '/fake-trackjs.js',
+      token: 'fake-token'
     }
   };
 

--- a/tests/dummy/public/fake-trackjs.js
+++ b/tests/dummy/public/fake-trackjs.js
@@ -2,7 +2,7 @@ window.trackJs = {
   configure: function(newOpts) {
     console.log("Configuring");
 
-    var originalOpts = window._trackJs;
+    var originalOpts = window._trackJs || {};
     var modifiedOpts = Ember.merge(originalOpts, newOpts);
 
     window._trackJs = modifiedOpts;


### PR DESCRIPTION
TODO
---------

- [ ] Test in a production application
- [ ] Get feedback
- [ ] Write up documentation on the breaking change in this pull request
- [ ] "enabled" must be set before injection :(
- [ ] Consider a separate config file altogether. Having two places to configure things is not fun.