### PR TITLE
Insert Script Tag at Foot of the `<head>` Tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
     var trackBoilerPlate;
     var addonConfig;
 
-    if (type === 'head') {
+    if (type === 'head-footer') {
       trackOpts = config.trackJs || {};
       trackConfig = trackOpts.config || {};
 


### PR DESCRIPTION
Ensures we're less likely to inflict damage to people's performance due
to tag ordering.