### PR TITLE
Fix App.container.lookup deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ problem we can use the `configure()` function in an initializer:
 // app/instance-initializers/configure-trackjs.js
 
 export function initialize(application) {
-  const trackJs = application.container.lookup('service:trackjs');
+  const trackJs = application.lookup('service:trackjs');
 
   trackJs.configure({
     onError(payload, err) {

--- a/app/instance-initializers/configure-trackjs.js
+++ b/app/instance-initializers/configure-trackjs.js
@@ -1,15 +1,17 @@
 import Ember from 'ember';
 import ErrorHandler from '../utils/error-handler';
 
-export function initialize(application) {
-  let trackJs = application.container.lookup('service:trackjs');
-  let appVersion = application.container.lookup('application:main').get('version');
+export function initialize(app) {
+  const instance = app.lookup ? app : app.container;
+
+  const trackJs = instance.lookup('service:trackjs');
+  const appVersion = instance.lookup('application:main').get('version');
 
   trackJs.configure({
     version: appVersion
   });
 
-  let handler = new ErrorHandler(trackJs);
+  const handler = new ErrorHandler(trackJs);
 
   Ember.onerror = handler.report.bind(handler);
 }


### PR DESCRIPTION
`ApplicationInstance.container.lookup` is deprecated in Ember 2.1. A new public API was introduced.

http://emberjs.com/deprecations/v2.x/#toc_ember-applicationinstance-container

