### PR TITLE
Fix IE8 ES6 compilation errors.

### DIFF
--- a/addon/services/trackjs.js
+++ b/addon/services/trackjs.js
@@ -6,7 +6,7 @@ import Ember from 'ember';
  * enough grief in trying to get this to work that this proxy seemed like the
  * easiest solution for now.
  */
-export default Ember.Service.extend({
+var TrackJS = Ember.Service.extend({
   track() {
     return window.trackJs && window.trackJs.track.apply(window.trackJs, arguments);
   },
@@ -41,3 +41,5 @@ export default Ember.Service.extend({
     }
   }
 });
+
+export default TrackJS;

--- a/addon/utils/error-handler.js
+++ b/addon/utils/error-handler.js
@@ -2,18 +2,18 @@ import Ember from 'ember';
 
 const Logger = Ember.Logger;
 
-class ErrorHandler {
-  constructor(reporter) {
-    this.reporter = reporter;
-  }
+var ErrorHandler = Ember.Object.extend({
+  init: function() {
+    this.reporter = this.get('reporter');
+  },
 
-  report(error) {
+  report: function(error) {
     // If you pass a POJO to TrackJS, you'll see "[object Object]"
     // in reports instead of object content. :(
 
     // If the error is an Error object, we pass it directly.
     if (error instanceof Error) {
-      this.reporter.track(error);
+      this.get('reporter').track(error);
       Logger.error(error.stack);
 
       return;
@@ -43,9 +43,9 @@ class ErrorHandler {
       }
     }
 
-    this.reporter.track(serializedError);
+    this.get('reporter').track(serializedError);
     Logger.error(error);
   }
-}
+});
 
 export default ErrorHandler;

--- a/app/instance-initializers/configure-trackjs.js
+++ b/app/instance-initializers/configure-trackjs.js
@@ -11,7 +11,7 @@ export function initialize(app) {
     version: appVersion
   });
 
-  const handler = new ErrorHandler(trackJs);
+  const handler = ErrorHandler.create({reporter: trackJs});
 
   Ember.onerror = handler.report.bind(handler);
 }

--- a/app/utils/error-handler.js
+++ b/app/utils/error-handler.js
@@ -1,1 +1,3 @@
-export { default } from 'ember-cli-trackjs/utils/error-handler';
+import ErrorHandler from 'ember-cli-trackjs/utils/error-handler';
+
+export default ErrorHandler;

--- a/tests/unit/utils/error-handler-test.js
+++ b/tests/unit/utils/error-handler-test.js
@@ -25,7 +25,7 @@ let handler = null;
 
 module('Unit | Utility | error handler', {
   beforeEach() {
-    handler = new ErrorHandler(trackJs);
+    handler = ErrorHandler.create({reporter: trackJs});
   },
 
   afterEach() {


### PR DESCRIPTION
This fixes #46. By changing addon/utils/error-handler.js from a class to an ember
object, I have gotten around the compilation that output
Object.defineProperty() which breaks in IE8.

Additionally, I've changed the import/export statements to a slightly more verbose syntax, but one that will be less likely to have output that is incompatible with ie8.

I have tested this and confirmed that it fixes the issues that I was having with IE8.