### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ problem we can use the `configure()` function in an initializer:
 // app/instance-initializers/configure-trackjs.js
 
 export function initialize(application) {
-  const trackJs = application.lookup('service:trackjs');
+  const trackJs = application.container.lookup('service:trackjs');
 
   trackJs.configure({
     onError(payload, err) {


### PR DESCRIPTION
`application.lookup` is not a function. Adding missing `container` in between.