### PR TITLE
Add TrackJS custom metadata api support

### DIFF
--- a/addon/services/trackjs.js
+++ b/addon/services/trackjs.js
@@ -27,6 +27,14 @@ export default Ember.Service.extend({
     return window.trackJs && window.trackJs.watchAll.apply(window.trackJs, arguments);
   },
 
+  addMetadata() {
+    return window.trackJs && window.trackJs.addMetadata.apply(window.trackJs, arguments);
+  },
+
+  removeMetadata() {
+    return window.trackJs && window.trackJs.removeMetadata.apply(window.trackJs, arguments);
+  },
+
   console: {
     error() {
       return window.trackJs && window.trackJs.console.error.apply(window.trackJs, arguments);

--- a/blueprints/ember-cli-trackjs/index.js
+++ b/blueprints/ember-cli-trackjs/index.js
@@ -8,7 +8,7 @@ module.exports = {
 
   afterInstall: function() {
     return this.addBowerPackagesToProject([
-      { name: 'trackjs', target: '~2.1.13' }
+      { name: 'trackjs', target: '~2.2.0' }
     ]);
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,6 @@
     "es5-shim": "^4.0.5"
   },
   "devDependencies": {
-    "trackjs": "~2.1.12"
+    "trackjs": "~2.2.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0",
     "sinonjs": "~1.14.1",

--- a/tests/unit/services/trackjs-test.js
+++ b/tests/unit/services/trackjs-test.js
@@ -9,6 +9,14 @@ let fakeTrackJs = {
   track() {
     return 'called it!';
   },
+
+  addMetadata(key, value) {
+    return key + value;
+  },
+
+  removeMetadata(key) {
+    return key;
+  }
 };
 
 moduleFor('service:trackjs', {
@@ -24,4 +32,14 @@ moduleFor('service:trackjs', {
 test('method proxying', function(assert) {
   let ret = this.subject().track();
   assert.equal(ret, 'called it!');
+});
+
+test('it proxies addMetadata to window.trackJs', function(assert) {
+  let ret = this.subject().addMetadata('add', 'custommetadata');
+  assert.equal(ret, 'addcustommetadata');
+});
+
+test('it proxies removeMetadata to window.trackJs', function(assert) {
+  let ret = this.subject().removeMetadata('removecustommetadata');
+  assert.equal(ret, 'removecustommetadata');
 });


### PR DESCRIPTION
- expose TrackJS `addMetadata` and `removeMetadata` methods in addon
service
- bump TrackJS dependency to `~2.2.0` for custom metadata features
- add unit tests for custom metadata
- resolves #50 