### PR TITLE
Fix equality typo in TypeError message check

### DIFF
--- a/addon/utils/error-handler.js
+++ b/addon/utils/error-handler.js
@@ -28,7 +28,7 @@ class ErrorHandler {
       serializedError = JSON.stringify(error, null, 2);
     } catch (e) {
       // Protecting against circular reference errors
-      if (e.message = "Converting circular structure to JSON") {
+      if (e.message === "Converting circular structure to JSON") {
         // We have an object with circular references and thus
         // we can't serialize it into JSON. We have to extract
         // info from it manually.


### PR DESCRIPTION
My linter noticed the check for an error thrown by `JSON.stringify()` was using the assignment operator; seems like that should actually be an equality check, no?

I spent some time trying to put together a test for this, but it [looks as if](https://msdn.microsoft.com/library/cc836459(v=vs.94).aspx#Anchor_3) the only other error thrown by `stringify()` relates to the replacer parameter, which is explicitly set in the error handler.