### PR TITLE
upgrades bower dependency for consuming applications

### DIFF
--- a/blueprints/ember-cli-trackjs/index.js
+++ b/blueprints/ember-cli-trackjs/index.js
@@ -8,7 +8,7 @@ module.exports = {
 
   afterInstall: function() {
     return this.addBowerPackagesToProject([
-      { name: 'trackjs', target: '~2.3.1' }
+      { name: 'trackjs', target: '~2.6.2' }
     ]);
   }
 };


### PR DESCRIPTION
Upgrades trackJS bower dependency in addon-consuming applications to 2.6.2 (same as addon devDependency).